### PR TITLE
Add Japanese labels for environment parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@ streamlit run -m sfgen.app
 
 Each run shows the environment parameters and up to ten valid ability
 bitstrings along with brief text descriptions.
+The ability names and environment parameter labels appear in Japanese in the UI.

--- a/sfgen/app.py
+++ b/sfgen/app.py
@@ -1,7 +1,12 @@
 import random
 import streamlit as st
 
-from data import ABILITIES, ENV_PARAMETERS, ABILITY_NAMES_JA
+from data import (
+    ABILITIES,
+    ENV_PARAMETERS,
+    ABILITY_NAMES_JA,
+    ENV_PARAMETER_NAMES_JA,
+)
 from core import mask_abilities, enumerate_valid_sets
 from template import render_species
 
@@ -34,7 +39,8 @@ def run() -> None:
 
     env = st.session_state['env']
     st.write("### 環境パラメータ")
-    st.json(env)
+    env_ja = {ENV_PARAMETER_NAMES_JA.get(k, k): v for k, v in env.items()}
+    st.json(env_ja)
 
     mask = mask_abilities(env)
     sets = enumerate_valid_sets(mask, DEPS)

--- a/sfgen/data.py
+++ b/sfgen/data.py
@@ -49,6 +49,18 @@ ENV_PARAMETERS = {
     "E8_tectonics": ["dead", "plate", "continuous_plume"],
 }
 
+# Japanese environment parameter names
+ENV_PARAMETER_NAMES_JA = {
+    "E1_gravity_g": "重力 (g)",
+    "E2_atmosphere": "大気組成",
+    "E3_surface_temp_C": "表面温度 (℃)",
+    "E4_liquid_medium": "液体媒体",
+    "E5_radiation_factor": "放射線レベル",
+    "E6_energy_gradient": "主なエネルギー勾配",
+    "E7_metal_silicate": "金属・ケイ素含有量",
+    "E8_tectonics": "地殻活動",
+}
+
 # Load compatibility matrix from YAML
 _COMP_PATH = os.path.join(os.path.dirname(__file__), "compatibility.yaml")
 if os.path.exists(_COMP_PATH):

--- a/sfgen/template.py
+++ b/sfgen/template.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from typing import Dict
 
-from data import ABILITIES, ABILITY_NAMES_JA
+from data import ABILITIES, ABILITY_NAMES_JA, ENV_PARAMETER_NAMES_JA
 
 
 TEMPLATES = {
@@ -14,7 +14,9 @@ TEMPLATES = {
 def render_species(bitset: int, env_vector: Dict[str, object]) -> str:
     """Render short description of species."""
     abilities_on = [ABILITY_NAMES_JA.get(name, name) for i, name in enumerate(ABILITIES) if bitset >> i & 1]
-    env_desc = '、'.join(f"{k}={v}" for k, v in env_vector.items())
+    env_desc = '、'.join(
+        f"{ENV_PARAMETER_NAMES_JA.get(k, k)}={v}" for k, v in env_vector.items()
+    )
     ability_str = '、'.join(abilities_on) if abilities_on else '能力なし'
     paragraphs = [
         TEMPLATES['ecology'].format(abilities=ability_str, env=env_desc),


### PR DESCRIPTION
## Summary
- support Japanese names for environment parameters
- display environment parameters in Japanese in the Streamlit app
- include Japanese labels in species descriptions
- document that the UI uses Japanese labels

## Testing
- `python -m py_compile sfgen/*.py`